### PR TITLE
global: removal of remaining Babel occurences

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -38,7 +38,6 @@ from __future__ import absolute_import, print_function
 import os
 
 from flask import Flask
-from flask_babelex import Babel
 from flask_cli import FlaskCLI
 from invenio_db import InvenioDB
 
@@ -46,7 +45,6 @@ from invenio_files_rest import InvenioFilesREST
 
 # Create Flask application
 app = Flask(__name__)
-Babel(app)
 InvenioFilesREST(app)
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
     'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ import shutil
 
 import pytest
 from flask import Flask
-from flask_babelex import Babel
 from flask_cli import FlaskCLI
 from invenio_db import db as db_
 from invenio_db import InvenioDB
@@ -50,7 +49,6 @@ def app(request):
     app_.config.update(
         TESTING=True
     )
-    Babel(app_)
     InvenioFilesREST(app_)
 
     app_.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(


### PR DESCRIPTION
* Removes Babel in example/app.py and
  test/conftest.py. (closes #4)

Signed-off-by: Guillaume Lastecoueres <guillaume@tind.io>