### PR TITLE
global: URL key as path

### DIFF
--- a/invenio_files_rest/views.py
+++ b/invenio_files_rest/views.py
@@ -717,7 +717,7 @@ blueprint.add_url_rule(
     methods=['GET', 'PUT', 'DELETE', 'HEAD']
 )
 blueprint.add_url_rule(
-    '/<string:bucket_id>/<string:key>',
+    '/<string:bucket_id>/<path:key>',
     view_func=object_view,
     methods=['GET', 'PUT', 'DELETE', 'HEAD']
 )


### PR DESCRIPTION
* Changes the 'key' argument type in URL pattern to path.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>