### PR TITLE
global: object key and file uri db type change

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,3 +70,9 @@ Exceptions
 .. automodule:: invenio_files_rest.errors
    :members:
    :undoc-members:
+
+Configuration
+-------------
+.. automodule:: invenio_files_rest.config
+   :members:
+   :undoc-members:

--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -43,3 +43,19 @@ FILES_REST_STORAGE_FACTORY = None
 
 FILES_REST_PERMISSION_FACTORY = None
 """Import path of permission factory."""
+
+FILES_REST_OBJECT_KEY_MAX_LEN = 255
+"""Maximum length of the ObjectVersion.key field.
+
+.. warning::
+   Setting this variable to anything higher than 255 is only supported
+   with PostgreSQL database.
+"""
+
+FILES_REST_FILE_URI_MAX_LEN = 255
+"""Maximum length of the FileInstance.uri field.
+
+.. warning::
+   Setting this variable to anything higher than 255 is only supported
+   with PostgreSQL database.
+"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -518,6 +518,13 @@ def test_object_relink_all(app, db, dummy_location):
     assert ObjectVersion.query.filter_by(file_id=fnew.id).count() == 2
 
 
+def test_object_validation(app, db, dummy_location):
+    """Test validating the ObjectVersion."""
+    b1 = Bucket.create()
+    ObjectVersion.create(b1, 'x' * 255)  # Should not raise
+    pytest.raises(ValueError, ObjectVersion.create, b1, 'x' * 256)
+
+
 def test_bucket_tags(app, db, dummy_location):
     """Test bucket tags."""
     b = Bucket.create()
@@ -695,3 +702,10 @@ def test_fileinstance_send_file(app, db, dummy_location):
     with app.test_request_context():
         res = f.send_file()
         assert int(res.headers['Content-Length']) == len(data)
+
+
+def test_fileinstance_validation(app, db, dummy_location):
+    """Test validating the FileInstance."""
+    f = FileInstance.create()
+    f.set_uri('x' * 255, 1000, 1000)  # Should not raise
+    pytest.raises(ValueError, f.set_uri, 'x' * 256, 1000, 1000)


### PR DESCRIPTION
* Changes the type of file URI and object key to db.Text with validation.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>