### PR TITLE
models: per bucket file size limits

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015 CERN.
+    Copyright (C) 2015, 2016 CERN.
 
     Invenio is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
@@ -27,7 +27,8 @@ Authors
 
 Files download/upload REST API similar to S3 for Invenio.
 
+- Jiri Kuncar <jiri.kuncar@cern.ch>
 - Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Nicolas Harraudeau <nicolas.harraudeau@cern.ch>
-- Jiri Kuncar <jiri.kuncar@cern.ch>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

--- a/invenio_files_rest/__init__.py
+++ b/invenio_files_rest/__init__.py
@@ -28,5 +28,6 @@ from __future__ import absolute_import, print_function
 
 from .ext import InvenioFilesREST
 from .version import __version__
+from .views import current_files_rest
 
-__all__ = ('__version__', 'InvenioFilesREST')
+__all__ = ('__version__', 'current_files_rest', 'InvenioFilesREST', )

--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -38,10 +38,20 @@ the file and/or what is the reliability.
 FILES_REST_DEFAULT_STORAGE_CLASS = 'S'
 """Default storage class."""
 
-FILES_REST_STORAGE_FACTORY = None
+FILES_REST_DEFAULT_QUOTA_SIZE = None
+"""Default quota size for a bucket in bytes."""
+
+FILES_REST_DEFAULT_MAX_FILE_SIZE = None
+"""Default maximum file size for a bucket in bytes."""
+
+FILES_REST_SIZE_LIMITERS = 'invenio_files_rest.limiters.file_size_limiters'
+"""Import path of file size limiters factory."""
+
+FILES_REST_STORAGE_FACTORY = 'invenio_files_rest.storage.pyfs_storage_factory'
 """Import path of factory used to create a storage instance."""
 
-FILES_REST_PERMISSION_FACTORY = None
+FILES_REST_PERMISSION_FACTORY = \
+    'invenio_files_rest.permissions.permission_factory'
 """Import path of permission factory."""
 
 FILES_REST_OBJECT_KEY_MAX_LEN = 255

--- a/invenio_files_rest/errors.py
+++ b/invenio_files_rest/errors.py
@@ -26,6 +26,8 @@
 
 from __future__ import absolute_import, print_function
 
+from invenio_rest.errors import RESTException
+
 
 class FilesException(Exception):
     """Base exception for all errors ."""
@@ -44,4 +46,10 @@ class FileInstanceAlreadySetError(FilesException):
 
 
 class InvalidOperationError(FilesException):
-    """Exception raise when an invalid operation is performed."""
+    """Exception raised when an invalid operation is performed."""
+
+
+class FileSizeError(RESTException):
+    """Exception raised when a file larger than allowed."""
+
+    code = 400

--- a/invenio_files_rest/helpers.py
+++ b/invenio_files_rest/helpers.py
@@ -85,15 +85,6 @@ def send_stream(stream, filename, size, mtime, mimetype=None, restricted=False,
     return rv
 
 
-def file_size_limiter(bucket):
-    """Retrieve the internal quota from the provided bucket."""
-    if bucket.quota_size:
-        return (bucket.quota_size - bucket.size,
-                'Bucket quota is {0} bytes. {1} bytes are currently '
-                'used.'.format(bucket.quota_size, bucket.size))
-    return (None, None)
-
-
 def compute_md5_checksum(src, chunk_size=None, progress_callback=None):
     """Helper method to compute checksum from a stream.
 

--- a/invenio_files_rest/limiters.py
+++ b/invenio_files_rest/limiters.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""File size limiting functionality for Invenio-Files-REST."""
+
+from __future__ import absolute_import, print_function
+
+
+def file_size_limiters(bucket):
+    """Default file size limiters."""
+    return [
+        FileSizeLimit(
+            bucket.quota_left,
+            'Bucket quota exceeded.',
+        ),
+        FileSizeLimit(
+            bucket.max_file_size,
+            'Maximum file size exceeded.',
+        ),
+    ]
+
+
+class FileSizeLimit(object):
+    """File size limiter."""
+
+    not_implemented_error = NotImplementedError(
+        'FileSizeLimit supports only comparisons with integers and other '
+        'FileSizeLimits.')
+
+    def __init__(self, limit, reason):
+        """Instantiate a new file size limit."""
+        self.limit = limit
+        self.reason = reason
+
+    def __lt__(self, other):
+        """Check if this limit is less than the other one."""
+        if isinstance(other, int):
+            return self.limit < other
+        elif isinstance(other, FileSizeLimit):
+            return self.limit < other.limit
+        raise self.not_implemented_error
+
+    def __gt__(self, other):
+        """Check if this limit is greater than the other one."""
+        if isinstance(other, int):
+            return self.limit > other
+        elif isinstance(other, FileSizeLimit):
+            return self.limit > other.limit
+        raise self.not_implemented_error
+
+    def __eq__(self, other):
+        """Check for equality."""
+        if isinstance(other, int):
+            return self.limit == other
+        elif isinstance(other, FileSizeLimit):
+            return self.limit == other.limit
+        raise self.not_implemented_error

--- a/invenio_files_rest/permissions.py
+++ b/invenio_files_rest/permissions.py
@@ -51,7 +51,7 @@ objects_delete_all = ObjectsDelete(None)
 _action2need_map = {
     'objects-read': ObjectsRead,
     'objects-update': ObjectsUpdate,
-    'objects-delete': ObjectsRead,
+    'objects-delete': ObjectsDelete,
 }
 
 

--- a/invenio_files_rest/proxies.py
+++ b/invenio_files_rest/proxies.py
@@ -31,3 +31,6 @@ from werkzeug.local import LocalProxy
 
 current_permission_factory = LocalProxy(
     lambda: current_app.extensions['invenio-files-rest'].permission_factory)
+
+current_files_rest = LocalProxy(
+    lambda: current_app.extensions['invenio-files-rest'])

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,7 @@ def objects(db, bucket):
     data_bytes2 = b('readme file')
     obj2 = ObjectVersion.create(
         bucket, 'README.rst', stream=BytesIO(data_bytes2),
-        size=len(data_bytes)
+        size=len(data_bytes2)
     )
     db.session.commit()
 

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -22,14 +22,31 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Helpers for invenio files REST's tests."""
+
+"""Test limiters."""
 
 from __future__ import absolute_import, print_function
 
-CONSTANT_FILE_SIZE_LIMIT = 120
-"""File size limit provided by the constant_file_size_limiter."""
+import pytest
+
+from invenio_files_rest.limiters import FileSizeLimit
 
 
-def constant_file_size_limiter(bucket):
-    """Provide always the same file size limit."""
-    return (CONSTANT_FILE_SIZE_LIMIT, 'Constant file size limit is exceeded')
+def test_file_size_limit_comparisons():
+    """Test FileSizeLimit comparison operators."""
+    bigger = FileSizeLimit(100, 'big limit')
+    smaller = FileSizeLimit(50, 'small limit')
+
+    assert bigger > smaller
+    assert smaller < bigger
+    assert bigger == bigger
+    assert bigger == 100
+    assert bigger > 50
+    assert bigger < 150
+
+    with pytest.raises(NotImplementedError):
+        bigger > 90.25
+    with pytest.raises(NotImplementedError):
+        bigger < 90.25
+    with pytest.raises(NotImplementedError):
+        bigger == 90.25


### PR DESCRIPTION
* Adds a per bucket maximum file size limit.

* File size limits are now checked while writing the object.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>