### PR TITLE
models: snapshot size population

### DIFF
--- a/invenio_files_rest/models.py
+++ b/invenio_files_rest/models.py
@@ -249,6 +249,7 @@ class Bucket(db.Model, Timestamp):
                 default_location=self.default_location,
                 default_storage_class=self.default_storage_class,
                 quota_size=self.quota_size,
+                size=self.size,
                 locked=True if lock else self.locked,
             )
             db.session.add(b)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -384,6 +384,7 @@ def test_object_snapshot(app, db, dummy_location):
     assert b1.locked is False
     assert b3.locked is True
 
+    assert b1.size == b3.size
     assert Bucket.query.count() == 3
     assert ObjectVersion.query.count() == 12
     assert FileInstance.query.count() == 7


### PR DESCRIPTION
* FIX Sets the size for Bucket snapshots.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>