### PR TITLE
ext: missing return

### DIFF
--- a/invenio_files_rest/ext.py
+++ b/invenio_files_rest/ext.py
@@ -45,7 +45,7 @@ class _FilesRESTState(object):
         """Load default storage factory."""
         imp = self.app.config.get("FILES_REST_RECORD_FILE_FACTORY")
         if imp:
-            import_string(imp)
+            return import_string(imp)
         else:
             try:
                 get_distribution('invenio-records-files')


### PR DESCRIPTION
* FIX Fixes missing return statement in
  `_FilesRESTState.record_file_factory()`.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>