### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Files-REST.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-files-rest
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/app.py
+++ b/examples/app.py
@@ -35,7 +35,7 @@ Initialize database
 
 Create a user (for accessing admin):
 
-   $ flask -a app.py users create info@invenio-software.org -a
+   $ flask -a app.py users create info@inveniosoftware.org -a
 
 Load some test data:
 

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     keywords='invenio files REST',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-files-rest',
     packages=packages,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,8 +173,8 @@ def objects(db, bucket):
 def users_data(db):
     """User data fixture."""
     return [
-        dict(email='user1@invenio-software.org', password='pass1'),
-        dict(email='user2@invenio-software.org', password='pass1'),
+        dict(email='user1@inveniosoftware.org', password='pass1'),
+        dict(email='user2@inveniosoftware.org', password='pass1'),
     ]
 
 


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>