### PR TITLE
errors: InvalidOperationError 403 code setting

### DIFF
--- a/invenio_files_rest/errors.py
+++ b/invenio_files_rest/errors.py
@@ -49,6 +49,8 @@ class UnexpectedFileSizeError(StorageError):
 class InvalidOperationError(FilesException):
     """Exception raised when an invalid operation is performed."""
 
+    code = 403
+
 
 class FileInstanceAlreadySetError(InvalidOperationError):
     """Exception raised when file instance already set on object."""


### PR DESCRIPTION
* Sets 403 as code for InvalidOperationError.
  (closes inveniosoftware/invenio-deposit#91)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>