### PR TITLE
views: handle missing Content-Type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,6 @@
 Changes
 =======
 
-Version 1.0.0a10 (released 2016-08-28)
+Version 1.0.0a11 (released 2016-09-13)
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==============================
- Invenio-Files-REST v1.0.0a10
+ Invenio-Files-REST v1.0.0a11
 ==============================
 
-Invenio-Files-REST v1.0.0a10 was released on August 28, 2016.
+Invenio-Files-REST v1.0.0a11 was released on September 13, 2016.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-files-rest==1.0.0a10
+   $ pip install invenio-files-rest==1.0.0a11
 
 Documentation
 -------------

--- a/invenio_files_rest/version.py
+++ b/invenio_files_rest/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a11.dev20160828"
+__version__ = "1.0.0a11"

--- a/invenio_files_rest/views.py
+++ b/invenio_files_rest/views.py
@@ -137,6 +137,7 @@ def default_partfactory(part_number=None, content_length=None,
     'content_type': fields.Str(
         load_from='Content-Type',
         location='headers',
+        missing='',
     ),
 })
 def stream_uploadfactory(content_md5=None, content_length=None,


### PR DESCRIPTION
* On stream uploads, sets the Content-Type header to and
  empty string ('') if missing.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>
Co-authored-by: Krzysztof Nowak <k.nowak@cern.ch>