### PR TITLE
global: fix the last modified conversion

### DIFF
--- a/invenio_files_rest/helpers.py
+++ b/invenio_files_rest/helpers.py
@@ -42,7 +42,7 @@ def send_stream(stream, filename, size, mtime, mimetype=None, restricted=True,
     :param stream: The file stream to send.
     :param filename: The file name.
     :param size: The file size.
-    :param mtime: A Unix timestamp that represents last modified time.
+    :param mtime: A Unix timestamp that represents last modified time (UTC).
     :param mimetype: The file mimetype. If ``None``, the module will try to
         guess. (Default: ``None``)
     :param restricted: If the file is not restricted, the module will set the

--- a/invenio_files_rest/storage/base.py
+++ b/invenio_files_rest/storage/base.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 import hashlib
 import time
+from calendar import timegm
 from functools import partial
 
 from ..errors import FileSizeError, StorageError, UnexpectedFileSizeError
@@ -75,8 +76,7 @@ class FileStorage(object):
     def __init__(self, size=None, modified=None):
         """Initialize storage object."""
         self._size = size
-        self._modified = \
-            time.mktime(modified.timetuple()) if modified else None
+        self._modified = timegm(modified.timetuple()) if modified else None
 
     def open(self, mode=None):
         """Open the file.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -23,8 +23,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-pydocstyle invenio_files_rest && \
-isort -rc -c -df **/*.py && \
+pydocstyle invenio_files_rest tests && \
+isort -rc -c -df . && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test && \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,13 +139,13 @@ def dummy_location(db):
 
 @pytest.fixture()
 def pyfs_testpath(dummy_location):
-    """PyFS test temporary path."""
+    """Temporary path for PyFS."""
     return os.path.join(dummy_location.uri, 'subpath/data')
 
 
 @pytest.fixture()
 def pyfs(dummy_location, pyfs_testpath):
-    """PyFSFileStorage instance."""
+    """Instance of PyFSFileStorage."""
     return PyFSFileStorage(pyfs_testpath)
 
 


### PR DESCRIPTION
* Fixes the incorrect conversion of last modified timestamps
  from localtime to UTC.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>