### PR TITLE
views: bad response code fix

### DIFF
--- a/invenio_files_rest/views.py
+++ b/invenio_files_rest/views.py
@@ -827,15 +827,12 @@ object_view = ObjectResource.as_view(
 blueprint.add_url_rule(
     '',
     view_func=location_view,
-    methods=['GET', 'POST']
 )
 blueprint.add_url_rule(
     '/<string:bucket_id>',
     view_func=bucket_view,
-    methods=['GET', 'PUT', 'DELETE', 'HEAD']
 )
 blueprint.add_url_rule(
     '/<string:bucket_id>/<path:key>',
     view_func=object_view,
-    methods=['GET', 'POST', 'PUT', 'DELETE', 'HEAD']
 )

--- a/tests/test_views_location.py
+++ b/tests/test_views_location.py
@@ -65,3 +65,16 @@ def test_post_bucket(app, client, headers, dummy_location, permissions,
             for key in expected_keys:
                 assert key in resp_json
             assert Bucket.get(resp_json['id'])
+
+
+@pytest.mark.parametrize('user, expected', [
+    (None, 405),
+    ('auth', 405),
+    ('location', 405),
+])
+def test_get_location(app, client, headers, dummy_location, permissions,
+                      user, expected):
+    """Test GET a location."""
+    login_user(client, permissions[user])
+    r = client.get(url_for('invenio_files_rest.location_api'), headers=headers)
+    assert r.status_code == expected


### PR DESCRIPTION
* Fixes issue with GET request to LocationResource replying with 500
  error instead of 405.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>