### PR TITLE
test: use mysql 5.7 for travis tests

### DIFF
--- a/.travis.install-mysql-5.7.sh
+++ b/.travis.install-mysql-5.7.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash -e
+
+if [ "$EXTRAS" = 'all,mysql' ]; then
+  # echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
+  # wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb
+  # sudo dpkg --install mysql-apt-config_0.7.3-1_all.deb
+  # sudo apt-get update -q
+  # sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server
+  # sudo service mysql restart
+  # sudo mysql_upgrade
+  # sudo service mysql restart
+
+    export MYSQL_HOME="${HOME}/mysql-5.7.17-linux-glibc2.5-x86_64"
+    cd ${HOME}
+    wget http://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.17-linux-glibc2.5-x86_64.tar.gz
+    echo "MYSQL DOWNLOAD OK"
+    tar -xzf mysql-5.7.17-linux-glibc2.5-x86_64.tar.gz
+    echo "MYSQL EXTRACT OK"
+    cd $MYSQL_HOME
+    echo "MYSQL CD OK"
+    mkdir data
+    mkdir log
+cat > my.cnf <<EOF
+[mysqld]
+user=<userName>
+EOF
+cat > my.ini <<EOF
+export BASE_DIR=${MYSQL_HOME}
+export DATADIR=${MYSQL_HOME}/data
+EOF
+    echo "MYSQL CONF OK"
+
+    $MYSQL_HOME/bin/mysqld --user=root --datadir=${MYSQL_HOME}/data \
+        --basedir=$MYSQL_HOME  --log-error=$MYSQL_HOME/log/mysql.err \
+        --pid-file=$MYSQL_HOME/mysql.pid --socket=$MYSQL_HOME/socket \
+        --port=3306 --initialize
+    echo "MYSQL INIT OK"
+    $MYSQL_HOME/bin/mysqld --user=root --datadir=${MYSQL_HOME}/data \
+        --basedir=$MYSQL_HOME  --log-error=$MYSQL_HOME/log/mysql.err \
+        --pid-file=$MYSQL_HOME/mysql.pid --socket=$MYSQL_HOME/socket \
+        --port=3306
+    echo "MYSQL START OK"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ cache:
     - $HOME/.cache/pip
 
 services:
-  - mysql
+  # - mysql
   - postgresql
   - redis
   - rabbitmq
@@ -44,14 +44,30 @@ services:
 # Note: dist/sudo/api is required for MySQL 5.6 which adds support for
 # fractional seconds in datetime columns.
 dist: trusty
-sudo: required
+# sudo: required
+sudo: false
 addons:
-   postgresql: "9.4"
-   apt:
-    packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
+  postgresql: "9.4"
+  # apt:
+    # sources:
+    #   - mysql-5.7-trusty This doesn't work for some reason
+    # packages:
+    #     - mysql-community-client
+    #     - mysql-community-server
+
+      # - mysql-server-5.7
+      # - mysql-client-core-5.7
+      # - mysql-client-5.7
+   # mysql: "5.7"
+   # apt: Enable this again once the travis version include the following patch
+   # https://bugs.mysql.com/bug.php?id=77591
+   #  packages:
+   #  - mysql-server-5.6
+   #  - mysql-client-core-5.6
+   #  - mysql-client-5.6
+cache:
+  directories:
+    - ${HOME}/mysql-5.7.13-linux-glibc2.5-x86_64
 
 env:
   - REQUIREMENTS=lowest EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
@@ -69,6 +85,7 @@ python:
   - "3.5"
 
 before_install:
+  - "bash .travis.install-mysql-5.7.sh"
   - "travis_retry pip install --upgrade pip setuptools py"
   - "travis_retry pip install twine wheel coveralls requirements-builder"
   - "travis_retry pip install --no-binary :all: psycopg2"

--- a/tests/test_invenio_files_rest.py
+++ b/tests/test_invenio_files_rest.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 from flask import Flask
+from invenio_db.utils import drop_alembic_version_table
 
 from invenio_files_rest import InvenioFilesREST
 
@@ -60,6 +61,7 @@ def test_alembic(app, db):
 
     assert not ext.alembic.compare_metadata()
     db.drop_all()
+    drop_alembic_version_table()
     ext.alembic.upgrade()
 
     assert not ext.alembic.compare_metadata()
@@ -68,3 +70,4 @@ def test_alembic(app, db):
     ext.alembic.upgrade()
 
     assert not ext.alembic.compare_metadata()
+    drop_alembic_version_table()


### PR DESCRIPTION
* Replaces mysql 5.6 with mysql 5.7 on travis because of a
  regression bug. (see https://bugs.mysql.com/bug.php?id=77591)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>