### PR TITLE
models: checksum_kwargs addition

### DIFF
--- a/invenio_files_rest/models.py
+++ b/invenio_files_rest/models.py
@@ -673,10 +673,11 @@ class FileInstance(db.Model, Timestamp):
 
     @ensure_readable()
     def update_checksum(self, progress_callback=None, chunk_size=None,
-                        **kwargs):
+                        checksum_kwargs=None, **kwargs):
         """Update checksum based on file."""
         self.checksum = self.storage(**kwargs).checksum(
-            progress_callback=progress_callback, chunk_size=chunk_size)
+            progress_callback=progress_callback, chunk_size=chunk_size,
+            **(checksum_kwargs or {}))
 
     def clear_last_check(self):
         """Clear the checksum of the file."""
@@ -686,7 +687,7 @@ class FileInstance(db.Model, Timestamp):
         return self
 
     def verify_checksum(self, progress_callback=None, chunk_size=None,
-                        throws=True, **kwargs):
+                        throws=True, checksum_kwargs=None, **kwargs):
         """Verify checksum of file instance.
 
         :param bool throws: If `True`, exceptions raised during checksum
@@ -694,10 +695,13 @@ class FileInstance(db.Model, Timestamp):
             an exception occurs, the `last_check` field is set to `None`
             (`last_check_at` of course is updated), since no check actually was
             performed.
+        :param dict checksum_kwargs: Passed as `**kwargs`` to
+            ``storage().checksum``.
         """
         try:
             real_checksum = self.storage(**kwargs).checksum(
-                progress_callback=progress_callback, chunk_size=chunk_size)
+                progress_callback=progress_callback, chunk_size=chunk_size,
+                **(checksum_kwargs or {}))
         except Exception as exc:
             current_app.logger.exception(str(exc))
             if throws:

--- a/invenio_files_rest/storage/base.py
+++ b/invenio_files_rest/storage/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -137,7 +137,7 @@ class FileStorage(object):
             fp.close()
             raise StorageError('Could not send file: {}'.format(e))
 
-    def checksum(self, chunk_size=None, progress_callback=None):
+    def checksum(self, chunk_size=None, progress_callback=None, **kwargs):
         """Compute checksum of file."""
         fp = self.open(mode='rb')
         try:
@@ -175,7 +175,7 @@ class FileStorage(object):
         return 'md5', hashlib.md5()
 
     def _compute_checksum(self, stream, size=None, chunk_size=None,
-                          progress_callback=None):
+                          progress_callback=None, **kwargs):
         """Get helper method to compute checksum from a stream.
 
         Naive implementation that can be overwritten by subclasses in order to
@@ -192,7 +192,7 @@ class FileStorage(object):
                 stream, algo, m,
                 chunk_size=chunk_size,
                 progress_callback=progress_callback,
-
+                **kwargs
             )
         except Exception as e:
             raise StorageError(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -27,7 +27,6 @@
 from __future__ import absolute_import, print_function
 
 import errno
-import logging
 from os.path import exists, join
 
 import pytest


### PR DESCRIPTION
* Adds an additional `checksum_kwargs` parameter to
  `FileInstance.verify_checksum` that is passed as `**kwargs` to
  `storage().checksum`.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>