### PR TITLE
tasks: checksum schedule task argument fixes

### DIFF
--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -132,7 +132,3 @@ FILES_REST_TASK_WAIT_INTERVAL = 2
 
 FILES_REST_TASK_WAIT_MAX_SECONDS = 600
 """Maximum number of seconds to wait for a task to finish."""
-
-FILES_REST_CHECKSUM_VERIFICATION_FILES_QUERY = \
-    'invenio_files_rest.tasks.default_checksum_verification_files_query'
-"""Function returning a FileInstance query for files that should be checked."""


### PR DESCRIPTION
* Passes `checksum_kwargs` correctly to the `verify_checksum` task.

* Adds a `files_query` argument for allowing different task
  configurations.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>