### PR TITLE
models: no location timestamp update on bucket creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,6 @@
 Changes
 =======
 
-Version 1.0.0a19 (released 2017-08-18)
+Version 1.0.0a20 (released 2017-09-27)
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==============================
- Invenio-Files-REST v1.0.0a19
+ Invenio-Files-REST v1.0.0a20
 ==============================
 
-Invenio-Files-REST v1.0.0a19 was released on August 18, 2017.
+Invenio-Files-REST v1.0.0a20 was released on September 27, 2017.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-files-rest==1.0.0a19
+   $ pip install invenio-files-rest==1.0.0a20
 
 Documentation
 -------------

--- a/examples/app.py
+++ b/examples/app.py
@@ -255,6 +255,7 @@ def files():
 
     # Create location
     loc = Location(name='local', uri=d, default=True)
+    db.session.add(loc)
     db.session.commit()
 
     # Bucket 0

--- a/invenio_files_rest/models.py
+++ b/invenio_files_rest/models.py
@@ -425,7 +425,7 @@ class Bucket(db.Model, Timestamp):
                 location = Location.get_by_name(location)
 
             obj = cls(
-                location=location,
+                default_location=location.id,
                 default_storage_class=storage_class or current_app.config[
                     'FILES_REST_DEFAULT_STORAGE_CLASS'],
                 **kwargs

--- a/invenio_files_rest/version.py
+++ b/invenio_files_rest/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0a19'
+__version__ = '1.0.0a20'


### PR DESCRIPTION
* Avoids updating location timestamps when creating buckets. This update
  is problematic when many concurrent tasks are creating buckets since
  the same row gets updated and can lead to deadlocks in the database.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>