### PR TITLE
views: fix compatibility with webargs 5.x

### DIFF
--- a/invenio_files_rest/views.py
+++ b/invenio_files_rest/views.py
@@ -389,7 +389,7 @@ class BucketResource(ContentNegotiatedMethodView):
 
     @use_kwargs(get_args)
     @pass_bucket
-    def get(self, bucket=None, versions=None, uploads=None):
+    def get(self, bucket=None, versions=missing, uploads=missing):
         """Get list of objects in the bucket.
 
         :param bucket: A :class:`invenio_files_rest.models.Bucket` instance.
@@ -763,7 +763,7 @@ class ObjectResource(ContentNegotiatedMethodView):
     @use_kwargs(post_args)
     @pass_bucket
     @need_bucket_permission('bucket-update')
-    def post(self, bucket=None, key=None, uploads=None, upload_id=None):
+    def post(self, bucket=None, key=None, uploads=missing, upload_id=None):
         """Upload a new object or start/complete a multipart upload.
 
         :param bucket: The bucket (instance or id) to get the object from.

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ install_requires = [
     'fs>=0.5.4,<2.0',
     'invenio-rest[cors]>=1.0.0a10',
     'webargs>=1.1.1',
+    'simplejson>=3.0.0',
 ]
 
 setup_requires = [


### PR DESCRIPTION
Changed the default arguments
for args that are both optional
and don't define `missing`
from `None` to `marshmallow.missing`.

I verified that the tests are passing
locally with the following webargs installations:

* latest `dev` branch
* webargs==5.1.0 (latest stable)
* webargs<5.0 (4.4.1 as of this writing)
* webargs==1.1.1 (min version in setup.py)

see #184