### PR TITLE
storage: customizable checksum algorithms for fixity

### DIFF
--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Invenio Files Rest module configuration file."""
-
+import hashlib
 from datetime import timedelta
 
 MAX_CONTENT_LENGTH = 16 * 1024 * 1024
@@ -132,3 +132,16 @@ FILES_REST_TASK_WAIT_INTERVAL = 2
 
 FILES_REST_TASK_WAIT_MAX_SECONDS = 600
 """Maximum number of seconds to wait for a task to finish."""
+
+FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS = {
+    'md5': hashlib.md5
+}
+"""Algorithms that can be used for file checksum compute and verify"""
+
+FILES_REST_CHECKSUM_ALGORITHM = 'md5'
+"""Checksum algorithm to be used on all newly uploaded files
+
+.. note::
+   Value of this variable must be a corresponding
+   key in the ``FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS`` variable.
+"""

--- a/invenio_files_rest/ext.py
+++ b/invenio_files_rest/ext.py
@@ -92,6 +92,19 @@ class _FilesRESTState(object):
             self.app.config.get('FILES_REST_UPLOAD_FACTORIES', [])
         ]
 
+    @cached_property
+    def supported_checksums(self):
+        """Load list of supported checksum algorithms."""
+        return load_or_import_from_config(
+            'FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS', app=self.app
+        )
+
+    @cached_property
+    def checksum_algorithm(self):
+        return self.app.config.get(
+            'FILES_REST_CHECKSUM_ALGORITHM', 'md5'
+        )
+
     def multipart_partfactory(self):
         """Get factory for content length, part number, stream for a part."""
         for factory in self.part_factories:

--- a/invenio_files_rest/models.py
+++ b/invenio_files_rest/models.py
@@ -727,9 +727,13 @@ class FileInstance(db.Model, Timestamp):
             ``storage().checksum``.
         """
         try:
+            checksum_kwargs = {
+                'algo': self.checksum.split(':', 1)[0],
+                **(checksum_kwargs or {})
+            }
             real_checksum = self.storage(**kwargs).checksum(
                 progress_callback=progress_callback, chunk_size=chunk_size,
-                **(checksum_kwargs or {}))
+                **checksum_kwargs)
         except Exception as exc:
             current_app.logger.exception(str(exc))
             if throws:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,11 @@ def base_app():
         FILES_REST_MULTIPART_MAX_PARTS=100,
         FILES_REST_TASK_WAIT_INTERVAL=0.1,
         FILES_REST_TASK_WAIT_MAX_SECONDS=1,
+        FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS={
+            'md5': hashlib.md5,
+            'sha256': hashlib.sha256
+        },
+        FILES_REST_CHECKSUM_ALGORITHM='md5'
     )
 
     FlaskCeleryExt(app_)
@@ -363,6 +368,16 @@ def get_md5():
         m = hashlib.md5()
         m.update(data)
         return "md5:{0}".format(m.hexdigest()) if prefix else m.hexdigest()
+    return inner
+
+
+@pytest.fixture()
+def get_sha256():
+    """Get SHA256 digest of data."""
+    def inner(data, prefix=True):
+        m = hashlib.sha256()
+        m.update(data)
+        return "sha256:{0}".format(m.hexdigest()) if prefix else m.hexdigest()
     return inner
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -74,6 +74,20 @@ def test_verify_checksum(app, db, dummy_location):
     f = FileInstance.query.get(file_id)
     assert f.last_check is None
 
+    # Create another file using MD5 checksum
+    with open('LICENSE', 'rb') as fp:
+        obj = ObjectVersion.create(b1, 'LICENSE', stream=fp)
+    db.session.commit()
+    file_id = obj.file_id
+
+    # Set checksums to SHA256, verify of previous MD5 checksums must work
+    app.extensions['invenio-files-rest'].checksum_algorithm = 'sha256'
+    verify_checksum(str(file_id))
+
+    f = FileInstance.query.get(file_id)
+    assert f.last_check_at
+    assert f.last_check is True
+
 
 def test_schedule_checksum_verification(app, db, dummy_location):
     """Test file checksum verification scheduling celery task."""


### PR DESCRIPTION
Adds the the possibility to customize the checksums that are computed on files by
using the following config options:

```python
FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS = {
    'md5': hashlib.md5
}
"""Algorithms that can be used for file checksum compute and verify"""

FILES_REST_CHECKSUM_ALGORITHM = 'md5'
"""Checksum algorithm to be used on all newly uploaded files

.. note::
   Value of this variable must be a corresponding
   key in the ``FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS`` variable.
"""
```

When the current checksum algorithm changes, newly created files will have the new checksum. Fixity checking of old files having a checksum generated by a previous algorithm is still maintained (as long as the algorithm remains in the ```FILES_REST_SUPPORTED_CHECKSUM_ALGORITHMS``` option).