### PR TITLE
errors: handle string error messages

### DIFF
--- a/invenio_files_rest/errors.py
+++ b/invenio_files_rest/errors.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import, print_function
 
+import six
 from invenio_rest.errors import RESTException
 
 
@@ -21,6 +22,15 @@ class FilesException(RESTException):
 
 class StorageError(FilesException):
     """Exception raised when a storage operation fails."""
+
+    def get_errors(self):
+        """Get errors.
+
+        :returns: A string with the error message.
+        """
+        if isinstance(self.errors, six.string_types):
+            return self.errors
+        return super(StorageError, self).get_errors()
 
 
 class UnexpectedFileSizeError(StorageError):


### PR DESCRIPTION
* The `StorageError` class is used in the codebase
  by passing a string as error. Due to the fact that
  inherits from the `RESTException` class, which assumes
  that the errors are a list, it was throwing a syntax error
  hiding the actual one.

closes inveniosoftware/invenio-rest#99