### PR TITLE
tests: remove asserts that seem to fail randomly

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,20 +103,15 @@ def test_simple_workflow(app, db, tmpdir):
     ], obj=script_info)
     assert 0 == result.exit_code
 
-    old_num_files = len(tmpdir.listdir())
-    # assert old_num_files == 2  # NOTE: this fails on github
-
     # Specify a file.
     result = runner.invoke(cmd, ['bucket', 'cp', __file__, bucket_id],
                            obj=script_info)
     assert 0 == result.exit_code
-
-    assert len(tmpdir.listdir()) == (old_num_files + 1)
+    prev_num_files = len(tmpdir.listdir())
 
     # No new file should be created.
     result = runner.invoke(cmd, [
         'bucket', 'cp', __file__, bucket_id, '--checksum'
     ], obj=script_info)
     assert 0 == result.exit_code
-
-    assert len(tmpdir.listdir()) == (old_num_files + 1)
+    assert len(tmpdir.listdir()) == prev_num_files


### PR DESCRIPTION
The asserts about number of files in the temp directory after executing CLI commands seem to fail sometimes on GitHub.