### PR TITLE
files_object: enforce unique is_head =True on postgresql

### DIFF
--- a/invenio_files_rest/alembic/a29271fd78f8_create_files_object_partial_unique_index.py
+++ b/invenio_files_rest/alembic/a29271fd78f8_create_files_object_partial_unique_index.py
@@ -1,6 +1,6 @@
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_files_rest/alembic/a29271fd78f8_create_files_object_partial_unique_index.py
+++ b/invenio_files_rest/alembic/a29271fd78f8_create_files_object_partial_unique_index.py
@@ -1,0 +1,29 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Create files object partial unique index."""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'a29271fd78f8'
+down_revision = '8ae99b034410'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    if op.get_context().dialect.name == 'postgresql':
+        op.create_index('ix_uq_partial_files_object_is_head', 'files_object', ['bucket_id', 'key'], unique=True, postgresql_where=sa.text('is_head'))
+
+
+def downgrade():
+    """Downgrade database."""
+    if op.get_context().dialect.name == 'postgresql':
+        op.drop_index('ix_uq_partial_files_object_is_head', table_name='files_object', postgresql_where=sa.text('is_head'))

--- a/invenio_files_rest/alembic/a29271fd78f8_create_files_object_partial_unique_index.py
+++ b/invenio_files_rest/alembic/a29271fd78f8_create_files_object_partial_unique_index.py
@@ -20,10 +20,12 @@ depends_on = None
 def upgrade():
     """Upgrade database."""
     if op.get_context().dialect.name == 'postgresql':
-        op.create_index('ix_uq_partial_files_object_is_head', 'files_object', ['bucket_id', 'key'], unique=True, postgresql_where=sa.text('is_head'))
+        op.create_index('ix_uq_partial_files_object_is_head', 'files_object',
+                        ['bucket_id', 'key'], unique=True,
+                        postgresql_where=sa.text('is_head'))
 
 
 def downgrade():
     """Downgrade database."""
     if op.get_context().dialect.name == 'postgresql':
-        op.drop_index('ix_uq_partial_files_object_is_head', table_name='files_object', postgresql_where=sa.text('is_head'))
+        op.drop_index('ix_uq_partial_files_object_is_head', table_name='files_object')

--- a/invenio_files_rest/models.py
+++ b/invenio_files_rest/models.py
@@ -413,7 +413,7 @@ class Bucket(db.Model, Timestamp):
     def validate_storage_class(self, key, default_storage_class):
         """Validate storage class."""
         if default_storage_class not in \
-            current_app.config['FILES_REST_STORAGE_CLASS_LIST']:
+                current_app.config['FILES_REST_STORAGE_CLASS_LIST']:
             raise ValueError('Invalid storage class.')
         return default_storage_class
 
@@ -889,8 +889,7 @@ class FileInstance(db.Model, Timestamp):
         self.readable = readable
         self.storage_class = \
             current_app.config['FILES_REST_DEFAULT_STORAGE_CLASS'] \
-                if storage_class is None else \
-                storage_class
+            if storage_class is None else storage_class
         return self
 
 
@@ -1298,7 +1297,7 @@ class ObjectVersion(db.Model, Timestamp):
     def __eq__(self, other):
         """Check if the two object are equals."""
         return other and isinstance(other, self.__class__) and \
-               self.key == other.key and self.file_id == other.file_id
+            self.key == other.key and self.file_id == other.file_id
 
     def __ne__(self, other):
         """Check if are not equal."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -111,7 +111,7 @@ def test_bucket_create_object(app, db):
         assert b.default_location == Location.get_default().id
         assert b.location == Location.get_default()
         assert b.default_storage_class == \
-            app.config['FILES_REST_DEFAULT_STORAGE_CLASS']
+               app.config['FILES_REST_DEFAULT_STORAGE_CLASS']
         assert b.size == 0
         assert b.quota_size is None
         assert b.max_file_size is None
@@ -193,17 +193,17 @@ def test_object_create(app, db, dummy_location):
 
     # Object __repr__
     assert repr(obj1) == \
-        u"{0}:{1}:{2}".format(
-            obj1.bucket_id, obj1.version_id, obj1.key)
+           u"{0}:{1}:{2}".format(
+               obj1.bucket_id, obj1.version_id, obj1.key)
 
     if sys.version_info[0] >= 3:  # python3
         assert repr(obj4) == \
-            u"{0}:{1}:{2}".format(
-                obj4.bucket_id, obj4.version_id, obj4.key)
+               u"{0}:{1}:{2}".format(
+                   obj4.bucket_id, obj4.version_id, obj4.key)
     else:  # python2
         assert repr(obj4) == \
-            u"{0}:{1}:{2}".format(
-                obj4.bucket_id, obj4.version_id, obj4.key).encode('utf-8')
+               u"{0}:{1}:{2}".format(
+                   obj4.bucket_id, obj4.version_id, obj4.key).encode('utf-8')
 
     # Sanity check
     assert ObjectVersion.query.count() == 4
@@ -226,6 +226,27 @@ def test_object_create(app, db, dummy_location):
     assert \
         ObjectVersion.get(b.id, "deleted_obj", version_id=obj3.version_id) == \
         obj3
+
+
+def test_object_create_uq_constraint(app, db, dummy_location):
+    """Test object creation unique constraint on is_head."""
+    # constraint is only enforced on postgresql
+    if db.engine.dialect.name != 'postgresql':
+        return
+
+    b = Bucket.create()
+
+    # Create 2 object version
+    obj1 = ObjectVersion(bucket=b, key="test", version_id=uuid.uuid4(), is_head=False, mimetype=None)
+    obj2 = ObjectVersion(bucket=b, key="test", version_id=uuid.uuid4(), is_head=True, mimetype=None)
+    db.session.add(obj1)
+    db.session.add(obj2)
+    db.session.commit()
+
+    # Create one invalid object version for same object key (is_head = True)
+    obj3 = ObjectVersion(bucket=b, key="test", version_id=uuid.uuid4(), is_head=True, mimetype=None)
+    db.session.add(obj3)
+    pytest.raises(IntegrityError, db.session.commit)
 
 
 def test_object_create_with_fileid(app, db, dummy_location):
@@ -562,9 +583,9 @@ def test_bucket_sync_add_deleted_object(app, db, dummy_location):
     """Test that adding back a deleted object in src is added in dest."""
     b1 = Bucket.create()
     b2 = Bucket.create()
-    obj1 = ObjectVersion.create(b1, "filename")\
+    obj1 = ObjectVersion.create(b1, "filename") \
         .set_location("b1v1", 1, "achecksum")
-    ObjectVersion.create(b1, "filename2")\
+    ObjectVersion.create(b1, "filename2") \
         .set_location("b1v2", 1, "achecksum2")
 
     db.session.commit()
@@ -993,7 +1014,7 @@ def test_object_version_tags(app, db, dummy_location):
     assert ObjectVersionTag.query.count() == 2
     assert ObjectVersionTag.get(obj1, "mykey").value == "testvalue"
     assert ObjectVersionTag.get_value(obj1.version_id, "another_key") \
-        == "another value"
+           == "another value"
     assert ObjectVersionTag.get_value(obj1, "invalid") is None
 
     # Test delete


### PR DESCRIPTION
Avoid inconsistent state on DB on race conditions.
For postgresql only. Mysql does not  support unique partial constraints.

Changes: 
- Model: add constraint to enforce only one object version is head
- Alembic: add migration