### PR TITLE
Add task for cleaning up orphan files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ tests =
     invenio-admin>=1.3.2
     invenio-db[postgresql,mysql,versioning]>=1.0.13,<2.0
     pytest-invenio>=1.4.7
-    Sphinx>=4.2.0
+    Sphinx>=4.2.0,<6
     sphinxcontrib-httpdomain>=1.4.0
 postgresql =
     # empty for backward compatibility


### PR DESCRIPTION
This PR adds a background task that deletes orphaned files from DB and disk (i.e. `FileInstance`s that don't have any `ObjectVersion`s linked with them anymore).
It is a slightly adapted version of our custom CLI command: https://gitlab.tuwien.ac.at/fairdata/invenio-utilities-tuw/-/blob/master/invenio_utilities_tuw/cli/files.py#L240

**Note**: The CLI command has been working well enough to clean up unreferenced files of deleted drafts, but I found that the `force` flag has to be provided because the storage is marked as not `writable`.

I'll still add tests for the new task, and then mark this as ready for review.