### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version 1.5.0 (release 2023-03-02)
+
+- remove deprecated flask-babelex dependency and imports
+- install invenio-i18n
+
 Version 1.4.0 (release 2023-01-24)
 
 - tasks: add orphan cleaning celery task

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2019 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -33,6 +33,10 @@ extensions = [
     "sphinxcontrib.httpdomain",
     "celery.contrib.sphinx",
 ]
+
+# to fix an celery.contrib.sphinx error. the default value '(task)' seams not
+# correct
+celery_task_prefix = ""
 
 nitpick_ignore = [
     ("py:class", "t.ClassVar"),

--- a/invenio_files_rest/__init__.py
+++ b/invenio_files_rest/__init__.py
@@ -973,7 +973,7 @@ a reference to the old :code:`FileInstance` to reference the new
 from .ext import InvenioFilesREST
 from .proxies import current_files_rest
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 __all__ = (
     "__version__",

--- a/invenio_files_rest/__init__.py
+++ b/invenio_files_rest/__init__.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -53,7 +54,7 @@ Now let's initialize all required Invenio extensions:
 >>> from pprint import pprint
 >>> import json
 
->>> from flask_babelex import Babel
+>>> from invenio_i18n import Babel
 >>> from flask_menu import Menu
 >>> from invenio_db import InvenioDB, db
 >>> from invenio_rest import InvenioREST

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     Flask-WTF>=0.15.1
     fs>=2.0.10,<3.0
     invenio-accounts>=1.4.10
+    invenio-i18n>=2.0.0
 
 [options.extras_require]
 tests =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -17,7 +18,6 @@ from io import BytesIO
 
 import pytest
 from flask import Flask, json, url_for
-from flask_babelex import Babel
 from flask_celeryext import FlaskCeleryExt
 from flask_menu import Menu
 from invenio_access import InvenioAccess
@@ -28,6 +28,7 @@ from invenio_accounts.views import blueprint as accounts_blueprint
 from invenio_db import InvenioDB
 from invenio_db import db as db_
 from invenio_db.utils import drop_alembic_version_table
+from invenio_i18n import Babel
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DropConstraint, DropSequence, DropTable
 from sqlalchemy_utils.functions import create_database, database_exists


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- fix: celery.contrib.sphinx make problems

- NOTE flask-security-invenio, invenio-i18n, invenio-admin, invenio-accounts, invenio-theme have to be released first