### PR TITLE
files: avoid creating directories while opening files for reading

### DIFF
--- a/invenio_files_rest/storage/pyfs.py
+++ b/invenio_files_rest/storage/pyfs.py
@@ -52,7 +52,11 @@ class PyFSFileStorage(FileStorage):
 
         The caller is responsible for closing the file.
         """
-        fs, path = self._get_fs()
+        if mode[0] == "r":
+            create_dir = False
+        else:
+            create_dir = True
+        fs, path = self._get_fs(create_dir=create_dir)
         return fs.open(path, mode=mode)
 
     def delete(self):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Opening a file fails if the user does not have write permissions. The  `open` seems to call mkdir, and that fails. 

This patch avoids creating directories if the file is opened only for reading.