### PR TITLE
Fix: Apply `invenio-accounts` API Changes

### DIFF
--- a/invenio_files_rest/__init__.py
+++ b/invenio_files_rest/__init__.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -61,7 +62,6 @@ Now let's initialize all required Invenio extensions:
 >>> from invenio_admin import InvenioAdmin
 >>> from invenio_accounts import InvenioAccounts
 >>> from invenio_access import InvenioAccess
->>> from invenio_accounts.views import blueprint as accounts_blueprint
 >>> from invenio_celery import InvenioCelery
 >>> from invenio_files_rest import InvenioFilesREST
 >>> from invenio_files_rest.views import blueprint
@@ -82,7 +82,6 @@ them manually and push a Flask application context:
 
 >>> ext_rest = InvenioFilesREST(app)
 
->>> app.register_blueprint(accounts_blueprint)
 >>> app.register_blueprint(blueprint)
 
 >>> app.app_context().push()

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ tests =
     invenio-admin>=1.3.2
     invenio-db[postgresql,mysql,versioning]>=1.0.13,<2.0
     pytest-invenio>=1.4.7
-    sphinx>=4.5.0
+    sphinx>=5.0.0,<6.0.0
     sphinxcontrib-httpdomain>=1.4.0
 
 postgresql =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2019 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,7 +25,6 @@ from invenio_access import InvenioAccess
 from invenio_access.models import ActionRoles, ActionUsers, Role
 from invenio_accounts import InvenioAccounts
 from invenio_accounts.testutils import create_test_user
-from invenio_accounts.views import blueprint as accounts_blueprint
 from invenio_db import InvenioDB
 from invenio_db import db as db_
 from invenio_db.utils import drop_alembic_version_table
@@ -116,7 +116,6 @@ def app(base_app):
     InvenioI18N(base_app)
     InvenioAccounts(base_app)
     InvenioAccess(base_app)
-    base_app.register_blueprint(accounts_blueprint)
     InvenioFilesREST(base_app)
     base_app.register_blueprint(blueprint)
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Fix failing tests
```log
tests/conftest.py:27: in <module>
    from invenio_accounts.views import blueprint as accounts_blueprint
E   ImportError: cannot import name 'blueprint' from 'invenio_accounts.views' (/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/invenio_accounts/views/__init__.py)
```
- This commit addresses compatibility issues caused by the recent API changes in the `invenio-accounts` module that is introduced in [this commit](https://github.com/Samk13/invenio-accounts/commit/5e1c58394d464d199d183302f65ab2084e08b621). It removes the usage of `accounts_blueprint` from invenio_files_rest and related tests, as it is no longer required and causes failures in the continuous integration (CI) tests. The change is aligned with the new release notes of invenio-accounts where this modification has been documented. 

- Updates the Sphinx dependency to `>=5.0.0,<6.0.0` addresses tests failing to lunch:
```log
ImportError: cannot import name 'formatargspec' from 'inspect'
```
 to resolve a compatibility issue with `Python 3.11`. This update is critical as `formatargspec`, used in [`celery.contrib.sphinx`](https://github.com/inveniosoftware/invenio-files-rest/blob/0b0cbafcc08dd2545117b318441757002dffd5ef/docs/conf.py#L34), has been removed in the new Python version. These changes align with ongoing efforts to upgrade Invenio to Python >3.11.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
