### PR TITLE
objecttag: Make the max length of the tag values configurable (defaul…

### DIFF
--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -68,6 +68,14 @@ FILES_REST_OBJECT_KEY_MAX_LEN = 255
    with PostgreSQL database.
 """
 
+FILES_REST_OBJECT_TAG_VALUE_MAX_LEN = 255
+"""Maximum length of the ObjectTag.value.uri field.
+
+.. warning::
+   Setting this variable to anything higher than 255 is only supported
+   with PostgreSQL database.
+"""
+
 FILES_REST_FILE_URI_MAX_LEN = 255
 """Maximum length of the FileInstance.uri field.
 

--- a/invenio_files_rest/models.py
+++ b/invenio_files_rest/models.py
@@ -1479,7 +1479,7 @@ class ObjectVersionTag(db.Model):
     def create(cls, object_version, key, value):
         """Create a new tag for a given object version."""
         assert len(key) < 256
-        assert len(value) < 256
+        assert len(value) <= current_app.config["FILES_REST_OBJECT_TAG_VALUE_MAX_LEN"]
         with db.session.begin_nested():
             obj = cls(
                 version_id=as_object_version_id(object_version), key=key, value=value
@@ -1491,7 +1491,7 @@ class ObjectVersionTag(db.Model):
     def create_or_update(cls, object_version, key, value):
         """Create or update a new tag for a given object version."""
         assert len(key) < 256
-        assert len(value) < 256
+        assert len(value) <= current_app.config["FILES_REST_OBJECT_TAG_VALUE_MAX_LEN"]
         obj = cls.get(object_version, key)
         if obj:
             obj.value = value


### PR DESCRIPTION
…t to 255)

:heart: Thank you for your contribution!

### Description
For Open Data, we store the 'cold' url of files as an object tag. Some of the uri are longer than 255, so it would be nice to set the limit as a parameter that can be tuned by the different instances.