### PR TITLE
I18n: Mark Missing Translations Backport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@
 Changes
 =======
 
+Version 2.2.5 (release 2025-03-18)
+
+- i18n: mark missing strings for translations
+
 Version 2.2.4 (release 2024-12-04)
 
 - workflows: add translation flag for publishing

--- a/invenio_files_rest/__init__.py
+++ b/invenio_files_rest/__init__.py
@@ -973,7 +973,7 @@ a reference to the old :code:`FileInstance` to reference the new
 from .ext import InvenioFilesREST
 from .proxies import current_files_rest
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 __all__ = (
     "__version__",

--- a/invenio_files_rest/storage/base.py
+++ b/invenio_files_rest/storage/base.py
@@ -117,7 +117,7 @@ class FileStorage(object):
         try:
             fp = self.open(mode="rb")
         except Exception as e:
-            raise StorageError(_("Could not send file: {error}").format(error=e))
+            raise StorageError(_("Could not send file: %(error)s") % {"error": e})
 
         try:
             md5_checksum = None
@@ -142,7 +142,7 @@ class FileStorage(object):
             )
         except Exception as e:
             fp.close()
-            raise StorageError(_("Could not send file: {error}").format(error=e))
+            raise StorageError(_("Could not send file: %(error)s") % {"error": e})
 
     def checksum(self, chunk_size=None, progress_callback=None, **kwargs):
         """Compute checksum of file."""
@@ -210,7 +210,7 @@ class FileStorage(object):
             )
         except Exception as e:
             raise StorageError(
-                _("Could not compute checksum of file: {error}").format(error=e)
+                _("Could not compute checksum of file: %(error)s") % {"error": e}
             )
 
     def _write_stream(

--- a/invenio_files_rest/storage/base.py
+++ b/invenio_files_rest/storage/base.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2019 CERN.
+# Copyright © 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +12,8 @@
 import hashlib
 from calendar import timegm
 from functools import partial
+
+from invenio_i18n import gettext as _
 
 from ..errors import FileSizeError, StorageError, UnexpectedFileSizeError
 from ..helpers import chunk_size_or_default, compute_checksum, send_stream
@@ -29,7 +32,7 @@ def check_sizelimit(size_limit, bytes_written, total_size):
     """
     if size_limit is not None and bytes_written > size_limit:
         desc = (
-            "File size limit exceeded."
+            _("File size limit exceeded.")
             if isinstance(size_limit, int)
             else size_limit.reason
         )
@@ -37,7 +40,7 @@ def check_sizelimit(size_limit, bytes_written, total_size):
 
     # Never write more than advertised
     if total_size is not None and bytes_written > total_size:
-        raise UnexpectedFileSizeError(description="File is bigger than expected.")
+        raise UnexpectedFileSizeError(description=_("File is bigger than expected."))
 
 
 def check_size(bytes_written, total_size):
@@ -49,7 +52,7 @@ def check_size(bytes_written, total_size):
         written exceed the total size.
     """
     if total_size and bytes_written < total_size:
-        raise UnexpectedFileSizeError(description="File is smaller than expected.")
+        raise UnexpectedFileSizeError(description=_("File is smaller than expected."))
 
 
 class FileStorage(object):
@@ -114,7 +117,7 @@ class FileStorage(object):
         try:
             fp = self.open(mode="rb")
         except Exception as e:
-            raise StorageError("Could not send file: {}".format(e))
+            raise StorageError(_("Could not send file: {error}").format(error=e))
 
         try:
             md5_checksum = None
@@ -139,7 +142,7 @@ class FileStorage(object):
             )
         except Exception as e:
             fp.close()
-            raise StorageError("Could not send file: {}".format(e))
+            raise StorageError(_("Could not send file: {error}").format(error=e))
 
     def checksum(self, chunk_size=None, progress_callback=None, **kwargs):
         """Compute checksum of file."""
@@ -206,7 +209,9 @@ class FileStorage(object):
                 **kwargs
             )
         except Exception as e:
-            raise StorageError("Could not compute checksum of file: {0}".format(e))
+            raise StorageError(
+                _("Could not compute checksum of file: {error}").format(error=e)
+            )
 
     def _write_stream(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,8 @@ invenio_db.alembic =
     invenio_files_rest = invenio_files_rest:alembic
 invenio_db.models =
     invenio_files_rest = invenio_files_rest.models
+invenio_i18n.translations =
+    invenio_files_rest = invenio_files_rest
 
 [build_sphinx]
 source-dir = docs/


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
