### PR TITLE
Adds range request support for accessing files to maint-v2.x

### DIFF
--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -133,5 +133,8 @@ FILES_REST_XSENDFILE_ENABLED = False
 """Use the X-Accel-Redirect header to stream the file through a reverse proxy(
     e.g NGINX)."""
 
+FILES_REST_ALLOW_RANGE_REQUESTS = False
+"""Enable support for HTTP Range Requests."""
+
 FILES_REST_XSENDFILE_RESPONSE_FUNC = create_file_streaming_redirect_response
 """Function for the creation of a file streaming redirect response."""

--- a/invenio_files_rest/helpers.py
+++ b/invenio_files_rest/helpers.py
@@ -184,7 +184,11 @@ def send_stream(
             rv.expires = int(time() + cache_timeout)
 
     if conditional:
-        rv = rv.make_conditional(request)
+        # make_conditional erroneously returns a 206 when accept_ranges is False
+        if current_app.config.get("FILES_REST_ALLOW_RANGE_REQUESTS", False):
+            rv = rv.make_conditional(request, accept_ranges=current_app.config.get("FILES_REST_ALLOW_RANGE_REQUESTS", False), complete_length=size)
+        else:
+            rv = rv.make_conditional(request)
 
     return rv
 

--- a/tests/test_views_objectversion.py
+++ b/tests/test_views_objectversion.py
@@ -9,6 +9,7 @@
 """Test object related views."""
 
 from datetime import timedelta, timezone
+from http import HTTPStatus
 from io import BytesIO
 from unittest.mock import patch
 
@@ -698,3 +699,120 @@ def test_put_header_invalid_tags(app, client, bucket, permissions, get_md5, get_
         headers={header_name: "a=1&a=2"},
     )
     assert resp.status_code == 400
+
+
+def test_get_range_request_enabled(
+    app, client, headers, bucket, permissions, monkeypatch
+):
+    """Test getting an object with Range header when range requests are enabled."""
+    app.config.update(
+        dict(
+            FILES_REST_ALLOW_RANGE_REQUESTS=True,
+        )
+    )
+
+    login_user(client, permissions["bucket"])
+
+    key = "range_test.txt"
+    content = b"0123456789" * 10  # 100 bytes of data
+    object_url = url_for("invenio_files_rest.object_api", bucket_id=bucket.id, key=key)
+
+    resp = client.put(object_url, input_stream=BytesIO(content))
+    assert resp.status_code == 200
+
+    # Test valid range request - first 10 bytes
+    headers_with_range = dict(headers)
+    headers_with_range["Range"] = "bytes=0-9"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == HTTPStatus.PARTIAL_CONTENT
+    assert resp.headers["Content-Range"] == "bytes 0-9/100"
+    assert resp.headers["Content-Length"] == "10"
+    assert resp.data == b"0123456789"
+
+    # Test valid range request - last 10 bytes
+    headers_with_range["Range"] = "bytes=90-99"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == HTTPStatus.PARTIAL_CONTENT
+    assert resp.headers["Content-Range"] == "bytes 90-99/100"
+    assert resp.headers["Content-Length"] == "10"
+    assert resp.data == b"0123456789"
+
+    # Test valid range request - middle bytes
+    headers_with_range["Range"] = "bytes=40-59"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == HTTPStatus.PARTIAL_CONTENT
+    assert resp.headers["Content-Range"] == "bytes 40-59/100"
+    assert resp.headers["Content-Length"] == "20"
+    assert resp.data == b"01234567890123456789"
+
+    # Test range request with only start byte specified
+    headers_with_range["Range"] = "bytes=90-"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == HTTPStatus.PARTIAL_CONTENT
+    assert resp.headers["Content-Range"] == "bytes 90-99/100"
+    assert resp.headers["Content-Length"] == "10"
+    assert resp.data == b"0123456789"
+
+    # Test range request with only suffix length specified
+    headers_with_range["Range"] = "bytes=-10"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == HTTPStatus.PARTIAL_CONTENT
+    assert resp.headers["Content-Range"] == "bytes 90-99/100"
+    assert resp.headers["Content-Length"] == "10"
+    assert resp.data == b"0123456789"
+
+    # Test invalid range request - start byte beyond file size
+    headers_with_range["Range"] = "bytes=100-109"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == 500
+
+    # Test invalid range request - start byte greater than end byte
+    headers_with_range["Range"] = "bytes=50-40"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == 500
+
+
+def test_get_range_request_disabled(
+    app, client, headers, bucket, permissions, monkeypatch
+):
+    """Test getting an object with Range header when range requests are disabled."""
+    app.config.update(
+        dict(
+            FILES_REST_ALLOW_RANGE_REQUESTS=False,
+        )
+    )
+
+    login_user(client, permissions["bucket"])
+
+    key = "range_test.txt"
+    content = b"0123456789" * 10  # 100 bytes of data
+    object_url = url_for("invenio_files_rest.object_api", bucket_id=bucket.id, key=key)
+
+    resp = client.put(object_url, input_stream=BytesIO(content))
+    assert resp.status_code == 200
+
+    # Test range request - should be ignored when disabled
+    headers_with_range = dict(headers)
+    headers_with_range["Range"] = "bytes=0-9"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == 200
+    assert "Content-Range" not in resp.headers
+    assert resp.headers["Content-Length"] == "100"
+    assert resp.data == content
+
+    # Try another range - should also be ignored
+    headers_with_range["Range"] = "bytes=40-59"
+    resp = client.get(object_url, headers=headers_with_range)
+
+    assert resp.status_code == 200
+    assert "Content-Range" not in resp.headers
+    assert resp.headers["Content-Length"] == "100"
+    assert resp.data == content


### PR DESCRIPTION
### Description

Note: This PR is similar to #321 except it is for the 2.x version of invenio-file-rest. 2.x relies on an earlier version of Werkzeug which doesn't behave the same/correctly as the version used by the 3.x version of Invenio-files rest. Therefore the implementation is slightly different.

This PR adds support for HTTP Range Request when accessing files. This is important for file types like [WACZ](https://www.loc.gov/preservation/digital/formats/fdd/fdd000586.shtml) or [PMTiles](https://docs.protomaps.com/pmtiles/) which can be quite large and are best accessed piecemeal.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
