### PR TITLE
fix: skip non-readable files on checksum verification

### DIFF
--- a/invenio_files_rest/admin.py
+++ b/invenio_files_rest/admin.py
@@ -16,6 +16,7 @@ from flask_admin.contrib.sqla import ModelView
 from flask_wtf import FlaskForm
 from invenio_admin.filters import FilterConverter
 from invenio_admin.forms import LazyChoices
+from invenio_db import db
 from markupsafe import Markup
 from wtforms.validators import ValidationError
 
@@ -337,7 +338,11 @@ class FileInstanceModelView(ModelView):
         try:
             count = 0
             for file_id in ids:
-                f = FileInstance.query.filter_by(id=uuid.UUID(file_id)).one_or_none()
+                f = (
+                    db.session.query(FileInstance)
+                    .filter_by(id=uuid.UUID(file_id))
+                    .one_or_none()
+                )
                 if f is None:
                     raise ValueError(_("Cannot find file instance."))
                 verify_checksum.delay(file_id)

--- a/invenio_files_rest/helpers.py
+++ b/invenio_files_rest/helpers.py
@@ -18,6 +18,7 @@ from time import time
 from urllib.parse import quote, urlsplit
 
 from flask import current_app, make_response, request
+from invenio_db import db
 from werkzeug.datastructures import Headers
 from werkzeug.wsgi import FileWrapper
 
@@ -287,9 +288,11 @@ def populate_from_path(bucket, source, checksum=True, key_prefix="", chunk_size=
             file_checksum = compute_md5_checksum(
                 open(path, "rb"), chunk_size=chunk_size
             )
-            file_instance = FileInstance.query.filter_by(
-                checksum=file_checksum, size=os.path.getsize(path)
-            ).first()
+            file_instance = (
+                db.session.query(FileInstance)
+                .filter_by(checksum=file_checksum, size=os.path.getsize(path))
+                .first()
+            )
             if file_instance:
                 return ObjectVersion.create(bucket, key, _file_id=file_instance.id)
         return ObjectVersion.create(bucket, key, stream=open(path, "rb"))

--- a/invenio_files_rest/tasks.py
+++ b/invenio_files_rest/tasks.py
@@ -62,7 +62,7 @@ def verify_checksum(
 
 def default_checksum_verification_files_query():
     """Return a query of valid FileInstances for checksum verification."""
-    return FileInstance.query.filter_by(readable=True)
+    return db.session.query(FileInstance).filter_by(readable=True)
 
 
 @shared_task(ignore_result=True)
@@ -254,7 +254,7 @@ def merge_multipartobject(upload_id, version_id=None):
     :returns: The :class:`invenio_files_rest.models.ObjectVersion` version
         ID.
     """
-    mp = MultipartObject.query.filter_by(upload_id=upload_id).one_or_none()
+    mp = db.session.query(MultipartObject).filter_by(upload_id=upload_id).one_or_none()
     if not mp:
         raise RuntimeError("Upload ID does not exists.")
     if not mp.completed:
@@ -327,7 +327,7 @@ def clear_orphaned_files(force_delete_check=lambda file_instance: False, limit=1
     """
     # with the tilde (~) operator, we get all file instances that *don't*
     # have any associated object versions
-    query = FileInstance.query.filter(~FileInstance.objects.any())
+    query = db.session.query(FileInstance).filter(~FileInstance.objects.any())
     if limit > 0:
         query = query.limit(limit)
 


### PR DESCRIPTION
### Description

`FileInstance` can be marked as non-readable. Currently, even those instances are read during checksum verification, which might raise an exception during file opening/reading. 

This commit fixes that by adding `readable=True` to the default checksum verification filter and changing the way the total size is computed to take this filter into account.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
