### PR TITLE
Fixes and improvements for range requests

### DIFF
--- a/invenio_files_rest/helpers.py
+++ b/invenio_files_rest/helpers.py
@@ -187,13 +187,16 @@ def send_stream(
             rv.expires = int(time() + cache_timeout)
 
     if conditional:
+        accept_ranges = current_app.config.get("FILES_REST_ALLOW_RANGE_REQUESTS", False)
         rv = rv.make_conditional(
             request,
-            accept_ranges=current_app.config.get(
-                "FILES_REST_ALLOW_RANGE_REQUESTS", False
-            ),
+            accept_ranges=accept_ranges,
             complete_length=size,
         )
+        if accept_ranges and "Accept-Ranges" not in rv.headers:
+            # werkzeug does not set Accept-Ranges header unless byte range is requested
+            # we want to advertise that we support byte ranges, so we set it here explicitly
+            rv.headers["Accept-Ranges"] = "bytes"
 
     return rv
 


### PR DESCRIPTION
### Description

* fix: Always send Accept-Ranges header if ranges are enabled
  * Ensures clients can detect range support upfront (previously, Werkzeug only sent the header after receiving a Range request).

* fix: Properly propagate Werkzeug’s range-related exceptions (e.g., RequestedRangeNotSatisfiable)
  * Replaces generic StorageError (HTTP 500) with correct HTTP 416 responses for invalid ranges.

* tests: Added coverage for malformed Range headers and range support advertisement
  * Verifies fixes and edge cases explicitly.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
