### PR TITLE
Router for storage factories

### DIFF
--- a/invenio_files_rest/config.py
+++ b/invenio_files_rest/config.py
@@ -54,8 +54,18 @@ FILES_REST_MIN_FILE_SIZE = 1
 FILES_REST_SIZE_LIMITERS = "invenio_files_rest.limiters.file_size_limiters"
 """Import path of file size limiters factory to control bucket size limits."""
 
+FILES_REST_STORAGE_FACTORIES = {}
+"""Specific storage factories for specific storage classes. The key is the storage class
+and the value is the import path of the factory used to create a storage instance 
+for that storage class. If a storage class is not found in this dict, 
+`FILES_REST_STORAGE_FACTORY` will be used to create the storage instance.
+"""
+
 FILES_REST_STORAGE_FACTORY = "invenio_files_rest.storage.pyfs_storage_factory"
 """Import path of factory used to create a storage instance."""
+
+FILES_REST_STORAGE_FACTORY_ROUTER = "invenio_files_rest.storage.storage_factory_router"
+"""Import path of factory used to route the creation of a storage instance."""
 
 FILES_REST_PERMISSION_FACTORY = "invenio_files_rest.permissions.permission_factory"
 """Permission factory to control the files access from the REST interface."""

--- a/invenio_files_rest/ext.py
+++ b/invenio_files_rest/ext.py
@@ -9,6 +9,7 @@
 """Files download/upload REST API similar to S3 for Invenio."""
 
 from flask import abort
+from invenio_base.utils import obj_or_import_string
 from werkzeug.exceptions import UnprocessableEntity
 from werkzeug.utils import cached_property
 
@@ -26,9 +27,26 @@ class _FilesRESTState(object):
         self.app = app
 
     @cached_property
-    def storage_factory(self):
+    def default_storage_factory(self):
         """Load default storage factory."""
         return load_or_import_from_config("FILES_REST_STORAGE_FACTORY", app=self.app)
+
+    @cached_property
+    def storage_factories(self):
+        """Load storage factories for specific storage classes."""
+        return {
+            storage_class: obj_or_import_string(factory_path)
+            for storage_class, factory_path in self.app.config.get(
+                "FILES_REST_STORAGE_FACTORIES", {}
+            ).items()
+        }
+
+    @cached_property
+    def storage_factory(self):
+        """Return the storage factory router."""
+        return load_or_import_from_config(
+            "FILES_REST_STORAGE_FACTORY_ROUTER", app=self.app
+        )
 
     @cached_property
     def permission_factory(self):

--- a/invenio_files_rest/storage/__init__.py
+++ b/invenio_files_rest/storage/__init__.py
@@ -10,9 +10,11 @@
 
 from .base import FileStorage
 from .pyfs import PyFSFileStorage, pyfs_storage_factory
+from .router import storage_factory_router
 
 __all__ = (
     "FileStorage",
     "pyfs_storage_factory",
     "PyFSFileStorage",
+    "storage_factory_router",
 )

--- a/invenio_files_rest/storage/router.py
+++ b/invenio_files_rest/storage/router.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""A router for directing file storage requests to the appropriate storage backend."""
+
+from invenio_files_rest.proxies import current_files_rest
+
+
+def storage_factory_router(*, fileinstance, **kwargs):
+    """Find the appropriate storage factory for a given file instance.
+
+    :param fileinstance: The file instance for which to find the storage factory.
+    :return: A storage factory function that can create a storage instance
+             for the given file instance
+             If a specific storage factory for the file instance's storage class
+             is not found, the default storage factory will be returned.
+    """
+    storage_class = fileinstance.storage_class
+    storage_factory = current_files_rest.storage_factories.get(
+        storage_class, current_files_rest.default_storage_factory
+    )
+    return storage_factory(fileinstance=fileinstance, **kwargs)

--- a/tests/test_storage_router.py
+++ b/tests/test_storage_router.py
@@ -1,0 +1,79 @@
+import pytest
+
+from invenio_files_rest.models import FileInstance
+
+
+class StandardStorage:
+    """A dummy storage class for testing purposes."""
+
+    def __init__(self, fileinstance, **kwargs):
+        self.fileinstance = fileinstance
+        self.kwargs = kwargs
+
+
+class ArchiveStorage:
+    """A dummy archive storage class for testing purposes."""
+
+    def __init__(self, fileinstance, **kwargs):
+        self.fileinstance = fileinstance
+        self.kwargs = kwargs
+
+
+def standard_storage_factory(fileinstance, **kwargs):
+    return StandardStorage(fileinstance=fileinstance, **kwargs)
+
+
+def archive_storage_factory(fileinstance, **kwargs):
+    return ArchiveStorage(fileinstance=fileinstance, **kwargs)
+
+
+def reset_cached_properties(obj, *property_names):
+    """Reset cached properties on an object."""
+    for property_name in property_names:
+        try:
+            del obj.__dict__[property_name]
+        except KeyError:
+            pass
+
+
+@pytest.fixture
+def app_with_router(app):
+    # TODO: we need a new setup to test it properly. This should go to fixtures.
+    previous_storage_factories = app.config["FILES_REST_STORAGE_FACTORIES"]
+    previous_default_storage_factory = app.config["FILES_REST_STORAGE_FACTORY"]
+    app.config["FILES_REST_STORAGE_FACTORIES"] = {
+        "A": archive_storage_factory,
+    }
+    app.config["FILES_REST_STORAGE_FACTORY"] = standard_storage_factory
+    reset_cached_properties(
+        app.extensions["invenio-files-rest"],
+        "storage_factory",
+        "default_storage_factory",
+        "storage_factories",
+    )
+
+    yield app
+
+    # reset back
+    app.config["FILES_REST_STORAGE_FACTORIES"] = previous_storage_factories
+    app.config["FILES_REST_STORAGE_FACTORY"] = previous_default_storage_factory
+    reset_cached_properties(
+        app.extensions["invenio-files-rest"],
+        "storage_factory",
+        "default_storage_factory",
+        "storage_factories",
+    )
+
+
+def test_storage_factory_router(app_with_router):
+    fi = FileInstance(storage_class="S")
+    storage = app_with_router.extensions["invenio-files-rest"].storage_factory(
+        fileinstance=fi
+    )
+    assert isinstance(storage, StandardStorage)
+
+    fi = FileInstance(storage_class="A")
+    storage = app_with_router.extensions["invenio-files-rest"].storage_factory(
+        fileinstance=fi
+    )
+    assert isinstance(storage, ArchiveStorage)


### PR DESCRIPTION
### Description

This PR introduces a storage factory router mechanism that enables dynamic selection of storage backends based on the `FileInstance.storage_class` field. This allows Invenio to support multiple storage backends simultaneously and route file operations to the appropriate storage implementation.

This change will help fixing the https://github.com/inveniosoftware/invenio-records-resources/issues/672


### Backward Compatibility

This change is fully backward compatible. Existing installations that don't configure `FILES_REST_STORAGE_FACTORIES` will continue to use the default storage factory for all file instances.


### Changes

* **Adds storage factory router**: New `storage_factory_router` function in `invenio_files_rest/storage/router.py` that routes storage instance creation based on the file instance's storage class.

* **Adds configuration options**:
  - `FILES_REST_STORAGE_FACTORIES`: Dict mapping storage classes to their specific factory import paths
  - `FILES_REST_STORAGE_FACTORY_ROUTER`: Import path for the router factory (default: `invenio_files_rest.storage.storage_factory_router`)

* **Updates extension state**: Modified `_FilesRESTState` class in `ext.py` to:
  - Introduce `default_storage_factory` property for the default storage factory
  - Add `storage_factories` property to load storage class-specific factories
  - Update `storage_factory` property to return the router instead of a single factory

* **Adds tests**: New test file `tests/test_storage_router.py` with tests validating:
  - Routing to default storage factory for unmatched storage classes
  - Routing to specific storage factory for matched storage classes

### Rationale

The `FileInstance` model already contains a `storage_class` field, but the framework previously lacked the mechanism to use this field for routing to different storage implementations. This PR fixes that by:

1. Enabling instances to use different storage backends based on their storage class
2. Maintaining backward compatibility through fallback to the default storage factory
3. Providing configuration-driven approach to storage backend selection

### Sequence Diagram

Dotted lines are already existing calls, solid lines were added. Previously, `current_files_rest` were just calling the single default factory.

```mermaid
sequenceDiagram
    update_checksum-->>FileInstance: storage()
    activate FileInstance
    FileInstance-->>current_files_rest: storage_factory(fileinstance=self)
    activate current_files_rest
    current_files_rest->>current_files_rest: load_or_import_from_config(FILES_REST_STORAGE_FACTORY_ROUTER)
    current_files_rest->>storage_factory_router: __call__(fileinstance)
    activate storage_factory_router
    storage_factory_router->>current_files_rest: storage_factories()
    activate current_files_rest
    current_files_rest->>current_files_rest: load_or_import_from_config(FILES_REST_STORAGE_FACTORIES)
    deactivate current_files_rest
    storage_factory_router->>selected_storage_factory: __call__(fileinstance)
    selected_storage_factory->>storage_factory_router: storage
    storage_factory_router->>current_files_rest: storage
    deactivate storage_factory_router
    current_files_rest-->>FileInstance: storage
    deactivate current_files_rest
    FileInstance-->>update_checksum: storage
    deactivate FileInstance
```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
